### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can even have use multiple formatters (see [RuboCop manual](https://github.c
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'rubocop-junit_formatter"
+gem 'rubocop-junit_formatter'
 ```
 
 You'll probably only need to scope it to the `test` group.


### PR DESCRIPTION
Fix gem installation instructions to have matching quotes

Just was browsing for a gem to use for this usecase and was gonna give this a try!
Copy pasting the gem line I realized the quotes weren't balanced!